### PR TITLE
config: CORS 허용 도메인 추가

### DIFF
--- a/src/main/java/kr/co/knuserver/global/config/WebMvcConfig.java
+++ b/src/main/java/kr/co/knuserver/global/config/WebMvcConfig.java
@@ -27,7 +27,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowedOrigins(
                         "http://localhost:3000",
-                        "http://localhost:8080"
+                        "http://localhost:8080",
+                        "http://localhost:5173",
+                        "https://knu-client.vercel.app"
                 )
                 .allowCredentials(true)
                 .maxAge(3600);


### PR DESCRIPTION
## ✨ 구현한 기능
- 클라이언트의 요청에 따라, CORS 허용 도메인 2개를 추가했습니다.

## 📢 논의하고 싶은 내용
-

## 🎸 기타
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 크로스 오리진 요청이 허용되는 도메인 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->