### PR TITLE
config: CORS 허용 도메인을 환경 변수로 분리

### DIFF
--- a/src/main/java/kr/co/knuserver/global/config/WebMvcConfig.java
+++ b/src/main/java/kr/co/knuserver/global/config/WebMvcConfig.java
@@ -2,6 +2,7 @@ package kr.co.knuserver.global.config;
 
 import kr.co.knuserver.global.auth.MemberIdArgumentResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -15,6 +16,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private final MemberIdArgumentResolver memberIdArgumentResolver;
 
+    @Value("${cors.allowed-origins}")
+    private String[] allowedOrigins;
+
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(memberIdArgumentResolver);
@@ -25,12 +29,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
-                .allowedOrigins(
-                        "http://localhost:3000",
-                        "http://localhost:8080",
-                        "http://localhost:5173",
-                        "https://knu-client.vercel.app"
-                )
+                .allowedOrigins(allowedOrigins)
                 .allowCredentials(true)
                 .maxAge(3600);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,9 @@ spring:
     restart:
       enabled: false
 
+cors:
+  allowed-origins: ${ALLOWED_ORIGINS}
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600000}


### PR DESCRIPTION
## ✨ 구현한 기능
- CORS 허용 도메인이 노출되는 문제가 있어 환경 변수로 분리하여 주입받도록 수정하였습니다.
- 디스코드에 변경된 `.env` 내용을 업로드 하였으니 확인해주시면 감사하겠습니다.

## 📢 논의하고 싶은 내용
-

## 🎸 기타
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CORS 원본(origin) 설정을 환경 변수를 통해 동적으로 구성할 수 있도록 개선했습니다. 이제 애플리케이션 배포 환경에 따라 유연하게 CORS 설정을 관리할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->