### PR TITLE
FIX: 부스 전체 조회 API 반환 형식 수정

### DIFF
--- a/src/main/java/kr/co/knuserver/presentation/booth/dto/BoothListResponseDto.java
+++ b/src/main/java/kr/co/knuserver/presentation/booth/dto/BoothListResponseDto.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 @Builder
 public record BoothListResponseDto(
     Long id,
+    Integer boothNumber,
     String name,
     BoothDivision division,
     String description,
@@ -16,6 +17,7 @@ public record BoothListResponseDto(
     public static BoothListResponseDto fromEntity(Booth entity, String firstImageUrl) {
         return BoothListResponseDto.builder()
             .id(entity.getId())
+            .boothNumber(entity.getBoothNumber())
             .name(entity.getName())
             .division(entity.getDivision())
             .description(entity.getDescription())


### PR DESCRIPTION
## ✨ 구현한 기능
- 부스 전체 조회 전용 dto의 부스 분과 필드를 수정했습니다.
  - 분과명이 String이 아니라 BoothDivision 타입으로 반환되도록 수정했습니다.
- 부스 전체 조회 전용 dto에 부스 번호 필드를 추가했습니다.

## 📢 논의하고 싶은 내용
-

## 🎸 기타
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 부스 목록 조회 응답에 부스 번호 정보가 추가되었습니다.
  * 부스 분류 정보 구조가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->