### PR TITLE
FIX: 부스 전체 조회 API 수정

### DIFF
--- a/src/main/java/kr/co/knuserver/application/booth/BoothQueryService.java
+++ b/src/main/java/kr/co/knuserver/application/booth/BoothQueryService.java
@@ -36,9 +36,34 @@ public class BoothQueryService {
             .toList();
         return BoothInfoResponseDto.fromEntity(booth, imageUrls);
     }
+
+
+    // 주어진 키워드를 바탕으로 부스 리스트 조회(페이지네이션 없는 버전)
+    public List<BoothInfoResponseDto> searchBoothsByKeyword1(String keyword) {
+        List<Booth> booths;
+
+        if (keyword == null || keyword.isBlank()) {
+            booths = boothRepository.findByIsActiveTrue();
+        }
+        else {
+            booths = boothRepository.searchByKeyword(keyword);
+        }
+
+        List<Long> boothIds = booths.stream().map(Booth::getId).toList();
+        Map<Long, List<String>> imageUrlsMap = boothImageRepository.findAllByBoothIdIn(boothIds).stream()
+            .collect(Collectors.groupingBy(
+                BoothImage::getBoothId,
+                Collectors.mapping(BoothImage::getImageUrl, Collectors.toList())
+            ));
+
+        return booths.stream()
+            .map(booth -> BoothInfoResponseDto.fromEntity(booth, imageUrlsMap.getOrDefault(booth.getId(), Collections.emptyList())))
+            .toList();
+    }
+
   
     // 주어진 키워드를 바탕으로 부스 리스트 조회 (커서 기반 페이지네이션)
-    public CursorPaginationResponse<BoothListResponseDto> searchBoothsByKeyword(String keyword, Long lastId, int size) {
+    public CursorPaginationResponse<BoothListResponseDto> searchBoothsByKeyword2(String keyword, Long lastId, int size) {
         Pageable pageable = PageRequest.of(0, size + 1);
         List<Booth> booths;
 

--- a/src/main/java/kr/co/knuserver/domain/booth/repository/BoothRepository.java
+++ b/src/main/java/kr/co/knuserver/domain/booth/repository/BoothRepository.java
@@ -12,6 +12,23 @@ public interface BoothRepository extends JpaRepository<Booth, Long> {
 
     List<Booth> findByIsActiveTrueAndIdGreaterThanOrderByIdAsc(Long lastId, Pageable pageable);
 
+    List<Booth> findByIsActiveTrue();
+
+    // 주어진 키워드가 부스명 or 부스 설명에 들어간 부스들을 조회(페이지네이션 X)
+    @Query("SELECT b FROM Booth b " +
+        "WHERE b.isActive = true " +
+        "AND (b.name LIKE CONCAT('%', :keyword, '%') " +
+        "  OR CONCAT(',', b.keywords, ',') LIKE CONCAT('%,', :keyword, ',%')) " +
+        "ORDER BY " +
+        "  CASE " +
+        "    WHEN b.name LIKE CONCAT('%', :keyword, '%') THEN 1 " + // 1순위: 이름에 키워드가 포함 (부분 일치)
+        "    ELSE 2 " +                                             // 2순위: keywords에 해당 키워드가 포함 (정확히 일치)
+        "  END ASC, " +
+        "  b.boothNumber ASC")
+    List<Booth> searchByKeyword(@Param("keyword") String keyword);
+
+
+    // 페이지네이션 전용
     @Query("SELECT b FROM Booth b " +
         "WHERE b.isActive = true " +
         "AND b.id > :lastId " +

--- a/src/main/java/kr/co/knuserver/presentation/booth/BoothApiController.java
+++ b/src/main/java/kr/co/knuserver/presentation/booth/BoothApiController.java
@@ -48,12 +48,24 @@ public class BoothApiController implements BoothApiControllerDocs {
     // 키워드 단위 가두모집 부스 리스트 조회
     @Override
     @GetMapping("/list")
+    public ResponseEntity<ApiResponse<List<BoothInfoResponseDto>>> searchBooths(
+        @RequestParam(name = "keyword", required = false) String keyword
+    ) {
+        List<BoothInfoResponseDto> result = boothQueryService.searchBoothsByKeyword1(keyword);
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ApiResponse.success(result));
+    }
+
+    // 키워드 단위 가두모집 부스 리스트 조회
+    @Override
+    @GetMapping("/list/pagination")
     public ResponseEntity<ApiResponse<CursorPaginationResponse<BoothListResponseDto>>> searchBooths(
         @RequestParam(name = "keyword", required = false) String keyword,
         @RequestParam(name = "lastId", required = false) Long lastId,
         @RequestParam(name = "size", required = false, defaultValue = "10") int size
     ) {
-        CursorPaginationResponse<BoothListResponseDto> result = boothQueryService.searchBoothsByKeyword(keyword, lastId, size);
+        CursorPaginationResponse<BoothListResponseDto> result = boothQueryService.searchBoothsByKeyword2(keyword, lastId, size);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ApiResponse.success(result));

--- a/src/main/java/kr/co/knuserver/presentation/booth/docs/BoothApiControllerDocs.java
+++ b/src/main/java/kr/co/knuserver/presentation/booth/docs/BoothApiControllerDocs.java
@@ -29,7 +29,17 @@ public interface BoothApiControllerDocs {
     ResponseEntity<kr.co.knuserver.global.exception.ApiResponse<BoothInfoResponseDto>> getBooth(
         @Parameter(description = "부스 ID", required = true) @PathVariable(name = "booth-id") Long boothId);
 
-    @Operation(summary = "키워드 단위 가두모집 부스 리스트 조회", description = "주어진 키워드가 부스명 or 부스 설명에 들어간 "
+    @Operation(summary = "키워드 단위 가두모집 부스 리스트 조회(페이지네이션 X)", description = "주어진 키워드가 부스명 or 부스 설명에 들어간 모든 "
+        + "부스를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "부스 조회 성공")
+    })
+    ResponseEntity<kr.co.knuserver.global.exception.ApiResponse<List<BoothInfoResponseDto>>> searchBooths(
+        @Parameter(description = "검색할 키워드 (입력하지 않으면 전체 조회)")
+        @RequestParam(name = "keyword", required = false) String keyword
+    );
+
+    @Operation(summary = "키워드 단위 가두모집 부스 리스트 조회(페이지네이션 적용)", description = "주어진 키워드가 부스명 or 부스 설명에 들어간 "
         + "부스를 커서 기반 페이지네이션으로 조회합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "부스 조회 성공")


### PR DESCRIPTION
## ✨ 구현한 기능
- 프론트 요청에 따라 부스 전체 조회 API에 페이지네이션이 없는 리스트 조회 API를 다시 추가합니다.

## 📢 논의하고 싶은 내용
-

## 🎸 기타
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 부스 검색 API 개선 - 키워드 기반 검색 및 페이지네이션 옵션 추가
* 검색어 없이 활성 부스 전체 조회 가능  
* 기존 커서 기반 페이지네이션 검색 기능 지속 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->