### PR TITLE
CHORE: 이벤트 전체 조회 API에 정렬 로직 추가

### DIFF
--- a/src/main/java/kr/co/knuserver/application/event/EventQueryService.java
+++ b/src/main/java/kr/co/knuserver/application/event/EventQueryService.java
@@ -26,7 +26,7 @@ public class EventQueryService {
     }
 
     public List<EventResponseDto> getEventListByEventType(EventType eventType) {
-        List<Event> events = eventRepository.findAllByEventTypeAndIsActiveTrue(eventType);
+        List<Event> events = eventRepository.findAllByEventTypeAndIsActiveTrueOrderByIdAsc(eventType);
 
         return events.stream()
             .map(EventResponseDto::fromEntity)

--- a/src/main/java/kr/co/knuserver/domain/event/repository/EventRepository.java
+++ b/src/main/java/kr/co/knuserver/domain/event/repository/EventRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
 
-    // 주어진 EventType 중 isActive==true인 event들만 리스트로 조회
-    List<Event> findAllByEventTypeAndIsActiveTrue(EventType eventType);
+    // 주어진 EventType 중 isActive==true인 event들만 리스트로 조회(id 오름차순)
+    List<Event> findAllByEventTypeAndIsActiveTrueOrderByIdAsc(EventType eventType);
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- 이벤트 전체 조회 API에 id 오름차순 정렬 로직을 추가했습니다.
- 메인 이벤트 -> 서브 이벤트 -> 사전 이벤트 -> 특별 이벤트 순서로 카드를 보여주고 싶었습니다.

## 📢 논의하고 싶은 내용
-

## 🎸 기타
- close #99 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
  * 이벤트 목록이 일관된 순서로 정렬되어 표시됩니다. 활성 상태의 이벤트들이 예측 가능한 순서로 정렬되므로 사용자 경험이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->