### PR TITLE
fix: logback SizeAndTimeBasedRollingPolicy로 deprecated 설정 교체

### DIFF
--- a/src/main/resources/logback/logback-prod.xml
+++ b/src/main/resources/logback/logback-prod.xml
@@ -18,12 +18,9 @@
       <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS}|%-5level|%32X{traceId:-},%16X{spanId:-}|%-40.40logger{39}|%m%n%nopex</pattern>
       <charset>utf8</charset>
     </encoder>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
       <fileNamePattern>${LOG_PATH}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
-      <timeBasedFileNamingAndTriggeringPolicy
-          class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-        <maxFileSize>100MB</maxFileSize>
-      </timeBasedFileNamingAndTriggeringPolicy>
+      <maxFileSize>100MB</maxFileSize>
       <maxHistory>7</maxHistory>
       <totalSizeCap>500MB</totalSizeCap>
     </rollingPolicy>


### PR DESCRIPTION
## ✨ 구현한 기능
- logback SizeAndTimeBasedRollingPolicy로 deprecated 설정 교체

## 📢 논의하고 싶은 내용
-

## 🎸 기타
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로덕션 환경의 로그 파일 관리 정책을 개선했습니다. 시간 기반 로그 회전에 파일 크기 기반 조건이 추가되어 디스크 공간 관리가 더욱 효율적으로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->