### PR TITLE
feat: SpringBoot lettuce pool 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.apache.commons:commons-pool2'
 
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,12 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       timeout: 3000ms
+      lettuce:
+        pool:
+          max-active: ${REDIS_POOL_MAX_ACTIVE:10}
+          max-idle: ${REDIS_POOL_MAX_IDLE:10}
+          min-idle: ${REDIS_POOL_MIN_IDLE:2}
+          max-wait: ${REDIS_POOL_MAX_WAIT:1000ms}
 
 device-id:
   cookie:


### PR DESCRIPTION
## 문제
- Redis 커넥션 풀 미설정
- resolve #105 

---

## 해결

### 1. commons-pool2 의존성 추가

Lettuce 풀링은 `GenericObjectPool`(commons-pool2)을 사용하며,
해당 클래스가 클래스패스에 없으면 `@ConditionalOnClass`로 인해 풀 설정이 **조용히 무시됨**.

```groovy
// build.gradle
implementation 'org.apache.commons:commons-pool2'
```

### 2. Lettuce 커넥션 풀 설정 추가

```yaml
# application.yml
spring:
  data:
    redis:
      host: ${REDIS_HOST:localhost}
      port: ${REDIS_PORT:6379}
      timeout: 3000ms
      lettuce:
        pool:
          max-active: ${REDIS_POOL_MAX_ACTIVE:10}   # 최대 커넥션 수
          max-idle: ${REDIS_POOL_MAX_IDLE:10}        # 유휴 커넥션 최대 보관 수
          min-idle: ${REDIS_POOL_MIN_IDLE:2}         # 미리 맺어둘 최소 커넥션 수
          max-wait: ${REDIS_POOL_MAX_WAIT:1000ms}    # 풀 고갈 시 대기 시간
```

각 값의 근거:

| 설정 | 값 | 근거 |
|---|---|---|
| max-active | 10 | Little's Law 산정값(6) + 안전 마진, Hikari(8)와 균형 |
| max-idle | 10 | max-active와 동일 → 반납 시 커넥션 재생성 비용 제거 |
| min-idle | 2 | 서버 기동 직후 cold start 지연 방지 |
| max-wait | 1000ms | Redis timeout(3000ms)보다 짧게 설정하여 빠른 실패 유도 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Redis 연결 풀 구성이 추가되어 데이터베이스 연결 관리가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->