### PR TITLE
FIX: NoticeCommandController API에 ADMIN(총동연)만 접근할 수 있도록 어노테이션 스위칭

### DIFF
--- a/src/main/java/kr/co/knuserver/presentation/notice/controller/NoticeCommandController.java
+++ b/src/main/java/kr/co/knuserver/presentation/notice/controller/NoticeCommandController.java
@@ -22,7 +22,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/admin/v1/notices")
 @RequiredArgsConstructor
-@RequireRole(Role.CLUB_ADMIN)
+@RequireRole(Role.ADMIN)
 public class NoticeCommandController implements NoticeCommandControllerDocs {
 
     private final NoticeCommandService noticeCommandService;


### PR DESCRIPTION
## ✨ 구현한 기능
- NoticeCommandController API에 ADMIN만 접근할 수 있도록 @RequireRole 어노테이션 스위칭

## 📢 논의하고 싶은 내용
-

## 🎸 기타
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **접근 제어**
  * 공지사항 관리 기능의 필요 권한이 변경되었습니다. 이제 ADMIN 역할을 가진 사용자만 공지사항 관련 작업을 수행할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->