### PR TITLE
feat: OPTION 메서드 쿠키 요청 제외

### DIFF
--- a/src/main/java/kr/co/knuserver/global/config/FilterConfig.java
+++ b/src/main/java/kr/co/knuserver/global/config/FilterConfig.java
@@ -19,6 +19,12 @@ public class FilterConfig {
     @Value("${device-id.cookie.max-age}")
     private int cookieMaxAge;
 
+    @Value("${device-id.cookie.same-site}")
+    private String cookieSameSite;
+
+    @Value("${device-id.cookie.secure}")
+    private boolean cookieSecure;
+
     private final DeviceIdGenerator deviceIdGenerator;
     private final LikeRateLimiter likeRateLimiter;
     private final ObjectMapper objectMapper;
@@ -33,7 +39,7 @@ public class FilterConfig {
 
     @Bean
     public FilterRegistrationBean<DeviceIdCookieFilter> deviceIdCookieFilter() {
-        DeviceIdCookieFilter filter = new DeviceIdCookieFilter(cookieMaxAge, deviceIdGenerator);
+        DeviceIdCookieFilter filter = new DeviceIdCookieFilter(cookieMaxAge, cookieSameSite, cookieSecure, deviceIdGenerator);
         FilterRegistrationBean<DeviceIdCookieFilter> bean = new FilterRegistrationBean<>(filter);
         bean.addUrlPatterns("/api/v1/booths/*");
         bean.setOrder(2);

--- a/src/main/java/kr/co/knuserver/global/filter/DeviceIdCookieFilter.java
+++ b/src/main/java/kr/co/knuserver/global/filter/DeviceIdCookieFilter.java
@@ -20,10 +20,14 @@ public class DeviceIdCookieFilter implements Filter {
     private static final String COOKIE_NAME = "deviceId";
 
     private final int cookieMaxAge;
+    private final String cookieSameSite;
+    private final boolean cookieSecure;
     private final DeviceIdGenerator deviceIdGenerator;
 
-    public DeviceIdCookieFilter(int cookieMaxAge, DeviceIdGenerator deviceIdGenerator) {
+    public DeviceIdCookieFilter(int cookieMaxAge, String cookieSameSite, boolean cookieSecure, DeviceIdGenerator deviceIdGenerator) {
         this.cookieMaxAge = cookieMaxAge;
+        this.cookieSameSite = cookieSameSite;
+        this.cookieSecure = cookieSecure;
         this.deviceIdGenerator = deviceIdGenerator;
     }
 
@@ -41,10 +45,7 @@ public class DeviceIdCookieFilter implements Filter {
         String deviceId = resolveDeviceId(httpRequest);
         if (deviceId == null) {
             deviceId = deviceIdGenerator.generate();
-            String cookieHeader = String.format(
-                "%s=%s; Path=/; Max-Age=%d; HttpOnly; SameSite=Lax; Secure",
-                COOKIE_NAME, deviceId, cookieMaxAge
-            );
+            String cookieHeader = buildCookieHeader(deviceId);
             httpResponse.addHeader("Set-Cookie", cookieHeader);
             log.debug("[DeviceId] 신규 발급 ip={} deviceId={}",
                 httpRequest.getAttribute(ClientIpFilter.CLIENT_IP_ATTRIBUTE), deviceId);
@@ -52,6 +53,16 @@ public class DeviceIdCookieFilter implements Filter {
 
         httpRequest.setAttribute(DEVICE_ID_ATTRIBUTE, deviceId);
         chain.doFilter(request, response);
+    }
+
+    private String buildCookieHeader(String deviceId) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("%s=%s; Path=/; Max-Age=%d; HttpOnly; SameSite=%s",
+            COOKIE_NAME, deviceId, cookieMaxAge, cookieSameSite));
+        if (cookieSecure) {
+            sb.append("; Secure");
+        }
+        return sb.toString();
     }
 
     private boolean isLikesPath(HttpServletRequest request) {

--- a/src/main/java/kr/co/knuserver/global/filter/DeviceIdCookieFilter.java
+++ b/src/main/java/kr/co/knuserver/global/filter/DeviceIdCookieFilter.java
@@ -41,11 +41,11 @@ public class DeviceIdCookieFilter implements Filter {
         String deviceId = resolveDeviceId(httpRequest);
         if (deviceId == null) {
             deviceId = deviceIdGenerator.generate();
-            Cookie cookie = new Cookie(COOKIE_NAME, deviceId);
-            cookie.setHttpOnly(true);
-            cookie.setPath("/");
-            cookie.setMaxAge(cookieMaxAge);
-            httpResponse.addCookie(cookie);
+            String cookieHeader = String.format(
+                "%s=%s; Path=/; Max-Age=%d; HttpOnly; SameSite=Lax; Secure",
+                COOKIE_NAME, deviceId, cookieMaxAge
+            );
+            httpResponse.addHeader("Set-Cookie", cookieHeader);
             log.debug("[DeviceId] 신규 발급 ip={} deviceId={}",
                 httpRequest.getAttribute(ClientIpFilter.CLIENT_IP_ATTRIBUTE), deviceId);
         }
@@ -55,6 +55,9 @@ public class DeviceIdCookieFilter implements Filter {
     }
 
     private boolean isLikesPath(HttpServletRequest request) {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            return false;
+        }
         String uri = request.getRequestURI();
         return uri.matches(".*/booths/[^/]+/likes$");
     }

--- a/src/main/java/kr/co/knuserver/global/ratelimit/LikeRateLimiter.java
+++ b/src/main/java/kr/co/knuserver/global/ratelimit/LikeRateLimiter.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 public class LikeRateLimiter {
 
     private static final String KEY = "like:rate:%s:%s";
-    private static final Duration WINDOW = Duration.ofMinutes(10);
 
     private final StringRedisTemplate redisTemplate;
     private final LikeProperties likeProperties;
@@ -19,6 +18,7 @@ public class LikeRateLimiter {
     public boolean isAllowed(String clientIp, String deviceId) {
         String key = KEY.formatted(clientIp, deviceId);
         long maxLikes = likeProperties.rateLimit().maxLikes();
+        Duration window = Duration.ofSeconds(likeProperties.rateLimit().ttlSeconds());
 
         String countStr = redisTemplate.opsForValue().get(key);
         long currentCount = countStr == null ? 0 : Long.parseLong(countStr);
@@ -29,7 +29,7 @@ public class LikeRateLimiter {
 
         Long newCount = redisTemplate.opsForValue().increment(key);
         if (newCount == 1) {
-            redisTemplate.expire(key, WINDOW);
+            redisTemplate.expire(key, window);
         }
 
         return true;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,8 @@ spring:
 device-id:
   cookie:
     max-age: ${DEVICE_ID_COOKIE_MAX_AGE:31536000} # 기본값 1년 (초 단위)
+    same-site: ${DEVICE_ID_COOKIE_SAME_SITE:Lax}
+    secure: ${DEVICE_ID_COOKIE_SECURE:true}
 
 like:
   rate-limit:


### PR DESCRIPTION
## ✨ 구현한 기능
- resolve #122
- OPTION 메서드 쿠키 요청 제외


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 주요 변경 사항

* **버그 수정**
  * 기기 ID 쿠키 처리 방식을 개선하고 보안 속성(HttpOnly, SameSite=Lax, Secure, Path, Max-Age)을 헤더 기반으로 강화했습니다.
  * 브라우저 프리플라이트(OPTIONS) 요청에 대해 필터가 적용되지 않도록 예외 처리했습니다.
* **개선**
  * 좋아요(rate limit) 제한 계산에서 만료 윈도우를 구성요소 설정값에 맞춰 동적으로 적용하도록 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->